### PR TITLE
Modularize card placement rules

### DIFF
--- a/src/main/java/com/github/markozajc/juno/game/BasicUnoGame.java
+++ b/src/main/java/com/github/markozajc/juno/game/BasicUnoGame.java
@@ -12,7 +12,8 @@ import com.github.markozajc.juno.cards.impl.UnoActionCard;
 import com.github.markozajc.juno.cards.impl.UnoDrawCard;
 import com.github.markozajc.juno.cards.impl.UnoWildCard;
 import com.github.markozajc.juno.hands.UnoHand;
-import com.github.markozajc.juno.utils.UnoUtils;
+import com.github.markozajc.juno.rules.pack.impl.UnoOfficialRules;
+import com.github.markozajc.juno.utils.UnoRuleUtils;
 
 /**
  * A {@link UnoGame} implementation that endorses the official UNO rules (see
@@ -97,7 +98,7 @@ public abstract class BasicUnoGame extends UnoGame {
 	 *            the second player's hand
 	 */
 	public BasicUnoGame(@Nonnull UnoHand playerOneHand, @Nonnull UnoHand playerTwoHand) {
-		super(playerOneHand, playerTwoHand, new UnoStandardDeck(), 7);
+		super(playerOneHand, playerTwoHand, new UnoStandardDeck(), 7, UnoOfficialRules.getPack());
 	}
 
 	private void changeColor(UnoHand hand, UnoCard card) {
@@ -118,6 +119,7 @@ public abstract class BasicUnoGame extends UnoGame {
 			((UnoDrawCard) card).setColor(color);
 	}
 
+	@SuppressWarnings("null")
 	@Override
 	protected void playHand(UnoHand hand) {
 		start: while (true) {
@@ -150,7 +152,8 @@ public abstract class BasicUnoGame extends UnoGame {
 
 					List<UnoCard> drawnCards = hand.draw(this.draw, draw);
 					onDrawCards(hand, draw);
-					if (drawnCards.size() == 1 && UnoUtils.analyzePossibleCards(topCard, drawnCards).size() == 1) {
+					if (drawnCards.size() == 1
+							&& UnoRuleUtils.combinedPlacementAnalysis(topCard, drawnCards, this.getRules(), hand).size() == 1) {
 						drawn = true;
 						continue;
 					}
@@ -160,7 +163,7 @@ public abstract class BasicUnoGame extends UnoGame {
 					return;
 				}
 
-				if (UnoUtils.analyzePossibleCards(topCard, Arrays.asList(card)).isEmpty()
+				if (UnoRuleUtils.combinedPlacementAnalysis(topCard, Arrays.asList(card), this.getRules(), hand).isEmpty()
 						|| !hand.getCards().remove(card)) {
 					// Should be checked by Hand implementation in the first place
 					onInvalidCard(hand, card);

--- a/src/main/java/com/github/markozajc/juno/game/UnoGame.java
+++ b/src/main/java/com/github/markozajc/juno/game/UnoGame.java
@@ -8,11 +8,13 @@ import com.github.markozajc.juno.decks.UnoDeck;
 import com.github.markozajc.juno.hands.UnoHand;
 import com.github.markozajc.juno.piles.impl.UnoDiscardPile;
 import com.github.markozajc.juno.piles.impl.UnoDrawPile;
+import com.github.markozajc.juno.rules.pack.UnoRulePack;
 
 /**
  * A class representing a UnoGame. UnoGame is the thing that controls flow and
  * actions that take place in a round of UNO. An implementation of this that endorses
- * official UNO rules is {@link BasicUnoGame} (see "Specification" in the README for the details)
+ * official UNO rules is {@link BasicUnoGame} (see "Specification" in the README for
+ * the details)
  *
  * @author Marko Zajc
  * @see BasicUnoGame
@@ -63,6 +65,9 @@ public abstract class UnoGame {
 	@Nonnull
 	public final UnoDiscardPile discard = new UnoDiscardPile();
 
+	@Nonnull
+	private final UnoRulePack rules;
+
 	/**
 	 * Returns the other {@link UnoPlayer}.
 	 *
@@ -105,11 +110,12 @@ public abstract class UnoGame {
 	 *            the amount of card each player gets initially
 	 */
 	public UnoGame(@Nonnull UnoHand playerOneHand, @Nonnull UnoHand playerTwoHand, @Nonnull UnoDeck unoDeck,
-			@Nonnegative int cardAmount) {
+			@Nonnegative int cardAmount, @Nonnull UnoRulePack rules) {
 		this.playerOneHand = playerOneHand;
 		this.playerTwoHand = playerTwoHand;
 		this.draw = new UnoDrawPile(unoDeck);
 		this.cardAmount = cardAmount;
+		this.rules = rules;
 	}
 
 	private void init() {
@@ -234,4 +240,10 @@ public abstract class UnoGame {
 
 		return null;
 	}
+
+	@Nonnull
+	public UnoRulePack getRules() {
+		return this.rules;
+	}
+
 }

--- a/src/main/java/com/github/markozajc/juno/game/UnoGame.java
+++ b/src/main/java/com/github/markozajc/juno/game/UnoGame.java
@@ -108,6 +108,8 @@ public abstract class UnoGame {
 	 *            the {@link UnoDeck} to use
 	 * @param cardAmount
 	 *            the amount of card each player gets initially
+	 * @param rules
+	 *            the {@link UnoRulePack} for this {@link UnoGame}
 	 */
 	public UnoGame(@Nonnull UnoHand playerOneHand, @Nonnull UnoHand playerTwoHand, @Nonnull UnoDeck unoDeck,
 			@Nonnegative int cardAmount, @Nonnull UnoRulePack rules) {
@@ -241,6 +243,9 @@ public abstract class UnoGame {
 		return null;
 	}
 
+	/**
+	 * @return the {@link UnoRulePack} in use by this {@link UnoGame}
+	 */
 	@Nonnull
 	public UnoRulePack getRules() {
 		return this.rules;

--- a/src/main/java/com/github/markozajc/juno/hands/impl/StrategicUnoHand.java
+++ b/src/main/java/com/github/markozajc/juno/hands/impl/StrategicUnoHand.java
@@ -14,11 +14,13 @@ import com.github.markozajc.juno.cards.impl.UnoNumericCard;
 import com.github.markozajc.juno.cards.impl.UnoWildCard;
 import com.github.markozajc.juno.game.UnoGame;
 import com.github.markozajc.juno.hands.UnoHand;
+import com.github.markozajc.juno.utils.UnoRuleUtils;
 import com.github.markozajc.juno.utils.UnoUtils;
 
 /**
- * An automated hand that uses actual strategic "thinking" to decide cards and colors to return.
- * Is suitable for production so you may use it as a "CPU" opponent in your code.
+ * An automated hand that uses actual strategic "thinking" to decide cards and colors
+ * to return. Is suitable for production so you may use it as a "CPU" opponent in
+ * your code.
  *
  * @author Marko Zajc
  */
@@ -27,7 +29,8 @@ public class StrategicUnoHand extends UnoHand {
 	/**
 	 * Creates a new {@link StrategicUnoHand}.
 	 *
-	 * @param name hand's name
+	 * @param name
+	 *            hand's name
 	 */
 	public StrategicUnoHand(@Nonnull String name) {
 		super(name);
@@ -117,10 +120,11 @@ public class StrategicUnoHand extends UnoHand {
 		// Fallback method
 	}
 
+	@SuppressWarnings("null")
 	@Override
 	public UnoCard playCard(UnoGame game, boolean drawn) {
 		UnoCard top = game.discard.getTop();
-		List<UnoCard> possible = UnoUtils.analyzePossibleCards(top, this.cards);
+		List<UnoCard> possible = UnoRuleUtils.combinedPlacementAnalysis(top, this.cards, game.getRules(), this);
 
 		if (possible.isEmpty())
 			return null;

--- a/src/main/java/com/github/markozajc/juno/hands/impl/StreamUnoHand.java
+++ b/src/main/java/com/github/markozajc/juno/hands/impl/StreamUnoHand.java
@@ -12,7 +12,7 @@ import com.github.markozajc.juno.cards.UnoCardColor;
 import com.github.markozajc.juno.cards.impl.UnoDrawCard;
 import com.github.markozajc.juno.game.UnoGame;
 import com.github.markozajc.juno.hands.UnoHand;
-import com.github.markozajc.juno.utils.UnoUtils;
+import com.github.markozajc.juno.utils.UnoRuleUtils;
 
 /**
  * A human-driven hand that uses a {@link Scanner} to read input and sends the output
@@ -31,9 +31,12 @@ public class StreamUnoHand extends UnoHand {
 	/**
 	 * Creates a new {@link StreamUnoHand}.
 	 *
-	 * @param name hand's name
-	 * @param is {@link InputStream} to read from
-	 * @param ps {@link PrintStream} to write to
+	 * @param name
+	 *            hand's name
+	 * @param is
+	 *            {@link InputStream} to read from
+	 * @param ps
+	 *            {@link PrintStream} to write to
 	 */
 	public StreamUnoHand(@Nonnull String name, @Nonnull InputStream is, @Nonnull PrintStream ps) {
 		super(name);
@@ -41,10 +44,11 @@ public class StreamUnoHand extends UnoHand {
 		this.ps = ps;
 	}
 
+	@SuppressWarnings("null")
 	@Override
 	public UnoCard playCard(UnoGame game, boolean drawn) {
 		UnoCard top = game.discard.getTop();
-		List<UnoCard> possible = UnoUtils.analyzePossibleCards(top, this.cards);
+		List<UnoCard> possible = UnoRuleUtils.combinedPlacementAnalysis(top, this.cards, game.getRules(), this);
 
 		this.ps.println("Choose a card:      [" + game.playerTwoHand.getName() + "'s hand size: "
 				+ game.playerTwoHand.getSize() + " | Draw pile size: " + game.draw.getSize() + " | Discard pile size: "

--- a/src/main/java/com/github/markozajc/juno/hands/impl/expreimental/PureRandomUnoHand.java
+++ b/src/main/java/com/github/markozajc/juno/hands/impl/expreimental/PureRandomUnoHand.java
@@ -9,7 +9,7 @@ import com.github.markozajc.juno.cards.UnoCard;
 import com.github.markozajc.juno.cards.UnoCardColor;
 import com.github.markozajc.juno.game.UnoGame;
 import com.github.markozajc.juno.hands.UnoHand;
-import com.github.markozajc.juno.utils.UnoUtils;
+import com.github.markozajc.juno.utils.UnoRuleUtils;
 
 /**
  * An automated hand that uses {@link Random} to decide everything. Still compiles
@@ -32,9 +32,11 @@ public class PureRandomUnoHand extends UnoHand {
 		super(name);
 	}
 
+	@SuppressWarnings("null")
 	@Override
 	public UnoCard playCard(UnoGame game, boolean drawn) {
-		List<UnoCard> possibilities = UnoUtils.analyzePossibleCards(game.discard.getTop(), this.cards);
+		List<UnoCard> possibilities = UnoRuleUtils.combinedPlacementAnalysis(game.discard.getTop(), this.cards,
+			game.getRules(), this);
 		if (possibilities.isEmpty())
 			return null;
 		return possibilities.get(RANDOM.nextInt(possibilities.size()));

--- a/src/main/java/com/github/markozajc/juno/rules/UnoRule.java
+++ b/src/main/java/com/github/markozajc/juno/rules/UnoRule.java
@@ -1,6 +1,8 @@
 package com.github.markozajc.juno.rules;
 
-
-public class UnoRule {
-
-}
+/**
+ * A meta-interface for UNO rules.
+ *
+ * @author Marko Zajc
+ */
+public interface UnoRule {}

--- a/src/main/java/com/github/markozajc/juno/rules/UnoRule.java
+++ b/src/main/java/com/github/markozajc/juno/rules/UnoRule.java
@@ -1,0 +1,6 @@
+package com.github.markozajc.juno.rules;
+
+
+public class UnoRule {
+
+}

--- a/src/main/java/com/github/markozajc/juno/rules/impl/ActionPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/ActionPlacementRules.java
@@ -6,6 +6,11 @@ import com.github.markozajc.juno.hands.UnoHand;
 import com.github.markozajc.juno.rules.pack.UnoRulePack;
 import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
 
+/**
+ * Placement rules for {@link UnoActionCard}.
+ *
+ * @author Marko Zajc
+ */
 public class ActionPlacementRules {
 
 	private ActionPlacementRules() {}

--- a/src/main/java/com/github/markozajc/juno/rules/impl/ActionPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/ActionPlacementRules.java
@@ -1,0 +1,49 @@
+package com.github.markozajc.juno.rules.impl;
+
+import com.github.markozajc.juno.cards.UnoCard;
+import com.github.markozajc.juno.cards.impl.UnoActionCard;
+import com.github.markozajc.juno.hands.UnoHand;
+import com.github.markozajc.juno.rules.pack.UnoRulePack;
+import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
+
+public class ActionPlacementRules {
+
+	private ActionPlacementRules() {}
+
+	private static UnoRulePack pack;
+
+	private static void createPack() {
+		pack = new UnoRulePack(new ActionPlacementRule());
+	}
+
+	/**
+	 * An action-based placement rule that allows {@link UnoActionCard}s of the same color to be placed
+	 * atop of each other and neutrals others.
+	 *
+	 * @author Marko Zajc
+	 */
+	public static class ActionPlacementRule extends UnoCardPlacementRule {
+
+		@Override
+		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
+			if (target instanceof UnoActionCard && card instanceof UnoActionCard
+					&& ((UnoActionCard) target).getAction().equals(((UnoActionCard) card).getAction()))
+				return PlacementClearance.ALLOWED;
+			// Checks whether target's action matches card's action
+
+			return PlacementClearance.NEUTRAL;
+		}
+
+	}
+
+	/**
+	 * @return {@link UnoRulePack} of the official action placement rules
+	 */
+	public static UnoRulePack getPack() {
+		if (pack == null)
+			createPack();
+
+		return pack;
+	}
+
+}

--- a/src/main/java/com/github/markozajc/juno/rules/impl/ActionPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/ActionPlacementRules.java
@@ -27,7 +27,7 @@ public class ActionPlacementRules {
 	 *
 	 * @author Marko Zajc
 	 */
-	public static class ActionPlacementRule extends UnoCardPlacementRule {
+	public static class ActionPlacementRule implements UnoCardPlacementRule {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {

--- a/src/main/java/com/github/markozajc/juno/rules/impl/ColorPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/ColorPlacementRules.java
@@ -44,7 +44,7 @@ public class ColorPlacementRules {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
-			if (target.getColor().equals(UnoCardColor.WILD))
+			if (card.getColor().equals(UnoCardColor.WILD))
 				return PlacementClearance.ALLOWED;
 
 			return PlacementClearance.NEUTRAL;

--- a/src/main/java/com/github/markozajc/juno/rules/impl/ColorPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/ColorPlacementRules.java
@@ -2,6 +2,7 @@ package com.github.markozajc.juno.rules.impl;
 
 import com.github.markozajc.juno.cards.UnoCard;
 import com.github.markozajc.juno.cards.UnoCardColor;
+import com.github.markozajc.juno.hands.UnoHand;
 import com.github.markozajc.juno.rules.pack.UnoRulePack;
 import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
 
@@ -17,35 +18,42 @@ public class ColorPlacementRules {
 
 	/**
 	 * A color-based placement rule that allows cards of the same color to be placed atop
-	 * of each other
+	 * of each other and neutrals others.
 	 *
 	 * @author Marko Zajc
 	 */
 	public static class ColorPlacementRule extends UnoCardPlacementRule {
 
 		@Override
-		public boolean canBePlaced(UnoCard target, UnoCard card) {
-			return target.getColor().equals(card.getColor());
+		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
+			if (target.getColor().equals(card.getColor()))
+				return PlacementClearance.ALLOWED;
+
+			return PlacementClearance.NEUTRAL;
 		}
 
 	}
 
 	/**
 	 * A color-based placement rule that allows a wild card to be placed atop of anything
+	 * and neutrals others.
 	 *
 	 * @author Marko Zajc
 	 */
 	public static class WildColorPlacementRule extends UnoCardPlacementRule {
 
 		@Override
-		public boolean canBePlaced(UnoCard target, UnoCard card) {
-			return target.getColor().equals(UnoCardColor.WILD);
+		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
+			if (target.getColor().equals(UnoCardColor.WILD))
+				return PlacementClearance.ALLOWED;
+
+			return PlacementClearance.NEUTRAL;
 		}
 
 	}
 
 	/**
-	 * @return {@link UnoRulePack} of the official color placement rules
+	 * @return {@link UnoRulePack} of the official color placement rules.
 	 */
 	public static UnoRulePack getPack() {
 		if (pack == null)

--- a/src/main/java/com/github/markozajc/juno/rules/impl/ColorPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/ColorPlacementRules.java
@@ -6,6 +6,11 @@ import com.github.markozajc.juno.hands.UnoHand;
 import com.github.markozajc.juno.rules.pack.UnoRulePack;
 import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
 
+/**
+ * {@link UnoCardColor}-based rules for all {@link UnoCard}s.
+ *
+ * @author Marko Zajc
+ */
 public class ColorPlacementRules {
 
 	private ColorPlacementRules() {}
@@ -22,7 +27,7 @@ public class ColorPlacementRules {
 	 *
 	 * @author Marko Zajc
 	 */
-	public static class ColorPlacementRule extends UnoCardPlacementRule {
+	public static class ColorPlacementRule implements UnoCardPlacementRule {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
@@ -40,7 +45,7 @@ public class ColorPlacementRules {
 	 *
 	 * @author Marko Zajc
 	 */
-	public static class WildColorPlacementRule extends UnoCardPlacementRule {
+	public static class WildColorPlacementRule implements UnoCardPlacementRule {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {

--- a/src/main/java/com/github/markozajc/juno/rules/impl/ColorPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/ColorPlacementRules.java
@@ -1,0 +1,57 @@
+package com.github.markozajc.juno.rules.impl;
+
+import com.github.markozajc.juno.cards.UnoCard;
+import com.github.markozajc.juno.cards.UnoCardColor;
+import com.github.markozajc.juno.rules.pack.UnoRulePack;
+import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
+
+public class ColorPlacementRules {
+
+	private ColorPlacementRules() {}
+
+	private static UnoRulePack pack;
+
+	private static void createPack() {
+		pack = new UnoRulePack(new ColorPlacementRule(), new WildColorPlacementRule());
+	}
+
+	/**
+	 * A color-based placement rule that allows cards of the same color to be placed atop
+	 * of each other
+	 *
+	 * @author Marko Zajc
+	 */
+	public static class ColorPlacementRule extends UnoCardPlacementRule {
+
+		@Override
+		public boolean canBePlaced(UnoCard target, UnoCard card) {
+			return target.getColor().equals(card.getColor());
+		}
+
+	}
+
+	/**
+	 * A color-based placement rule that allows a wild card to be placed atop of anything
+	 *
+	 * @author Marko Zajc
+	 */
+	public static class WildColorPlacementRule extends UnoCardPlacementRule {
+
+		@Override
+		public boolean canBePlaced(UnoCard target, UnoCard card) {
+			return target.getColor().equals(UnoCardColor.WILD);
+		}
+
+	}
+
+	/**
+	 * @return {@link UnoRulePack} of the official color placement rules
+	 */
+	public static UnoRulePack getPack() {
+		if (pack == null)
+			createPack();
+
+		return pack;
+	}
+
+}

--- a/src/main/java/com/github/markozajc/juno/rules/impl/DrawPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/DrawPlacementRules.java
@@ -1,0 +1,54 @@
+package com.github.markozajc.juno.rules.impl;
+
+import com.github.markozajc.juno.cards.UnoCard;
+import com.github.markozajc.juno.cards.impl.UnoDrawCard;
+import com.github.markozajc.juno.hands.UnoHand;
+import com.github.markozajc.juno.rules.pack.UnoRulePack;
+import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
+
+public class DrawPlacementRules {
+
+	private DrawPlacementRules() {}
+
+	private static UnoRulePack pack;
+
+	private static void createPack() {
+		pack = new UnoRulePack(/* TODO */);
+	}
+
+	public class DrawAmountPlacementRule extends UnoCardPlacementRule {
+
+		@Override
+		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
+			if (target instanceof UnoDrawCard && card instanceof UnoDrawCard
+					&& ((UnoDrawCard) target).getAmount() == ((UnoDrawCard) card).getAmount())
+				return PlacementClearance.ALLOWED;
+			// Checks whether target's amount matches card's amount
+
+			return PlacementClearance.NEUTRAL;
+		}
+	}
+
+	public class DrawFourHitchPlacementRule extends UnoCardPlacementRule {
+
+		@Override
+		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
+			if (target instanceof UnoDrawCard && card instanceof UnoDrawCard) {
+				// TODO
+			}
+
+			return PlacementClearance.NEUTRAL;
+		}
+	}
+
+	/**
+	 * @return {@link UnoRulePack} of the official draw placement rules
+	 */
+	public static UnoRulePack getPack() {
+		if (pack == null)
+			createPack();
+
+		return pack;
+	}
+
+}

--- a/src/main/java/com/github/markozajc/juno/rules/impl/DrawPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/DrawPlacementRules.java
@@ -20,7 +20,7 @@ public class DrawPlacementRules {
 	private static UnoRulePack pack;
 
 	private static void createPack() {
-		pack = new UnoRulePack(new DrawAmountPlacementRule(), new DrawFourHitchPlacementRule());
+		pack = new UnoRulePack(new DrawAmountPlacementRule(), new DrawFourHitchPlacementRule(), new UnplayedCardPlacementRule());
 	}
 
 	public static class DrawAmountPlacementRule extends UnoCardPlacementRule {
@@ -40,15 +40,27 @@ public class DrawPlacementRules {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
-			if (card instanceof UnoDrawCard && target.getColor().equals(UnoCardColor.WILD)
-					&& !UnoUtils.getColorCards(target.getColor(), hand.getCards()).isEmpty()) {
+			if (card instanceof UnoDrawCard && !target.getColor().equals(UnoCardColor.WILD)
+					&& ((UnoDrawCard) card).getAmount() == 4
+					&& !UnoUtils.getColorCards(target.getColor(), hand.getCards()).isEmpty())
 				return PlacementClearance.PROHIBITED;
-			}
 			// Prohibits the placement of the wild draw four if the hand possesses a card that
 			// has the same color as the target (assumed to be the top of the discard pile) card.
 
 			return PlacementClearance.NEUTRAL;
 		}
+	}
+
+	public static class UnplayedCardPlacementRule extends UnoCardPlacementRule {
+
+		@Override
+		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
+			if (target instanceof UnoDrawCard && !((UnoDrawCard) target).isPlayed())
+				return PlacementClearance.PROHIBITED;
+
+			return PlacementClearance.NEUTRAL;
+		}
+
 	}
 
 	/**

--- a/src/main/java/com/github/markozajc/juno/rules/impl/DrawPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/DrawPlacementRules.java
@@ -20,10 +20,17 @@ public class DrawPlacementRules {
 	private static UnoRulePack pack;
 
 	private static void createPack() {
-		pack = new UnoRulePack(new DrawAmountPlacementRule(), new DrawFourHitchPlacementRule(), new UnplayedCardPlacementRule());
+		pack = new UnoRulePack(new DrawAmountPlacementRule(), new DrawFourHitchPlacementRule(),
+				new UnplayedCardPlacementRule());
 	}
 
-	public static class DrawAmountPlacementRule extends UnoCardPlacementRule {
+	/**
+	 * An amount-based placement rule that allows {@link UnoDrawCard} of the same amount
+	 * to be placed on each other.
+	 *
+	 * @author Marko Zajc
+	 */
+	public static class DrawAmountPlacementRule implements UnoCardPlacementRule {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
@@ -36,7 +43,14 @@ public class DrawPlacementRules {
 		}
 	}
 
-	public static class DrawFourHitchPlacementRule extends UnoCardPlacementRule {
+	/**
+	 * The extra "hitch" to the draw four; prohibits placement of wild draw four on a
+	 * card in case its holder has a hand of the same color as that card (doesn't apply
+	 * to wild-colored cards).
+	 *
+	 * @author Marko Zajc
+	 */
+	public static class DrawFourHitchPlacementRule implements UnoCardPlacementRule {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
@@ -51,7 +65,13 @@ public class DrawPlacementRules {
 		}
 	}
 
-	public static class UnplayedCardPlacementRule extends UnoCardPlacementRule {
+	/**
+	 * A placement rule that prohibits all cards from being placed on an unplayed
+	 * {@link UnoDrawCard}.
+	 *
+	 * @author Marko Zajc
+	 */
+	public static class UnplayedCardPlacementRule implements UnoCardPlacementRule {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {

--- a/src/main/java/com/github/markozajc/juno/rules/impl/DrawPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/DrawPlacementRules.java
@@ -1,11 +1,18 @@
 package com.github.markozajc.juno.rules.impl;
 
 import com.github.markozajc.juno.cards.UnoCard;
+import com.github.markozajc.juno.cards.UnoCardColor;
 import com.github.markozajc.juno.cards.impl.UnoDrawCard;
 import com.github.markozajc.juno.hands.UnoHand;
 import com.github.markozajc.juno.rules.pack.UnoRulePack;
 import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
+import com.github.markozajc.juno.utils.UnoUtils;
 
+/**
+ * Placement rules for {@link UnoDrawCard}.
+ *
+ * @author Marko Zajc
+ */
 public class DrawPlacementRules {
 
 	private DrawPlacementRules() {}
@@ -13,10 +20,10 @@ public class DrawPlacementRules {
 	private static UnoRulePack pack;
 
 	private static void createPack() {
-		pack = new UnoRulePack(/* TODO */);
+		pack = new UnoRulePack(new DrawAmountPlacementRule(), new DrawFourHitchPlacementRule());
 	}
 
-	public class DrawAmountPlacementRule extends UnoCardPlacementRule {
+	public static class DrawAmountPlacementRule extends UnoCardPlacementRule {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
@@ -29,13 +36,16 @@ public class DrawPlacementRules {
 		}
 	}
 
-	public class DrawFourHitchPlacementRule extends UnoCardPlacementRule {
+	public static class DrawFourHitchPlacementRule extends UnoCardPlacementRule {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
-			if (target instanceof UnoDrawCard && card instanceof UnoDrawCard) {
-				// TODO
+			if (card instanceof UnoDrawCard && target.getColor().equals(UnoCardColor.WILD)
+					&& !UnoUtils.getColorCards(target.getColor(), hand.getCards()).isEmpty()) {
+				return PlacementClearance.PROHIBITED;
 			}
+			// Prohibits the placement of the wild draw four if the hand possesses a card that
+			// has the same color as the target (assumed to be the top of the discard pile) card.
 
 			return PlacementClearance.NEUTRAL;
 		}

--- a/src/main/java/com/github/markozajc/juno/rules/impl/NumericPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/NumericPlacementRules.java
@@ -27,7 +27,7 @@ public class NumericPlacementRules {
 	 *
 	 * @author Marko Zajc
 	 */
-	public static class NumericPlacementRule extends UnoCardPlacementRule {
+	public static class NumericPlacementRule implements UnoCardPlacementRule {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {

--- a/src/main/java/com/github/markozajc/juno/rules/impl/NumericPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/NumericPlacementRules.java
@@ -1,0 +1,49 @@
+package com.github.markozajc.juno.rules.impl;
+
+import com.github.markozajc.juno.cards.UnoCard;
+import com.github.markozajc.juno.cards.impl.UnoNumericCard;
+import com.github.markozajc.juno.hands.UnoHand;
+import com.github.markozajc.juno.rules.pack.UnoRulePack;
+import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
+
+public class NumericPlacementRules {
+
+	private NumericPlacementRules() {}
+
+	private static UnoRulePack pack;
+
+	private static void createPack() {
+		pack = new UnoRulePack(new NumericPlacementRule());
+	}
+
+	/**
+	 * A number-based placement rule that allows {@link UnoNumericCard}s of the same
+	 * number to be placed atop of each other and neutrals others.
+	 *
+	 * @author Marko Zajc
+	 */
+	public static class NumericPlacementRule extends UnoCardPlacementRule {
+
+		@Override
+		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
+			if (target instanceof UnoNumericCard && card instanceof UnoNumericCard
+					&& ((UnoNumericCard) target).getNumber() == ((UnoNumericCard) card).getNumber())
+				return PlacementClearance.ALLOWED;
+			// Checks whether target's number matches card's number
+
+			return PlacementClearance.NEUTRAL;
+		}
+
+	}
+
+	/**
+	 * @return {@link UnoRulePack} of the official number placement rules
+	 */
+	public static UnoRulePack getPack() {
+		if (pack == null)
+			createPack();
+
+		return pack;
+	}
+
+}

--- a/src/main/java/com/github/markozajc/juno/rules/impl/NumericPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/NumericPlacementRules.java
@@ -6,6 +6,11 @@ import com.github.markozajc.juno.hands.UnoHand;
 import com.github.markozajc.juno.rules.pack.UnoRulePack;
 import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
 
+/**
+ * Placement rules for {@link UnoNumericCard}.
+ *
+ * @author Marko Zajc
+ */
 public class NumericPlacementRules {
 
 	private NumericPlacementRules() {}

--- a/src/main/java/com/github/markozajc/juno/rules/impl/WildPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/WildPlacementRules.java
@@ -29,7 +29,7 @@ public class WildPlacementRules {
 	 *
 	 * @author Marko Zajc
 	 */
-	public static class WildPlacementRule extends UnoCardPlacementRule {
+	public static class WildPlacementRule implements UnoCardPlacementRule {
 
 		@Override
 		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {

--- a/src/main/java/com/github/markozajc/juno/rules/impl/WildPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/WildPlacementRules.java
@@ -1,0 +1,52 @@
+package com.github.markozajc.juno.rules.impl;
+
+import com.github.markozajc.juno.cards.UnoCard;
+import com.github.markozajc.juno.cards.impl.UnoWildCard;
+import com.github.markozajc.juno.hands.UnoHand;
+import com.github.markozajc.juno.rules.pack.UnoRulePack;
+import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
+
+/**
+ * Placement rules for {@link UnoWildCard}.
+ *
+ * @author Marko Zajc
+ */
+public class WildPlacementRules {
+
+	private WildPlacementRules() {}
+
+	private static UnoRulePack pack;
+
+	private static void createPack() {
+		pack = new UnoRulePack(new WildPlacementRule());
+	}
+
+	/**
+	 * The only official rule for the {@link UnoWildCard} - the wild card can be placed
+	 * on literally anything.
+	 *
+	 * @author Marko Zajc
+	 */
+	public static class WildPlacementRule extends UnoCardPlacementRule {
+
+		@Override
+		public PlacementClearance canBePlaced(UnoCard target, UnoCard card, UnoHand hand) {
+			if (card instanceof UnoWildCard)
+				return PlacementClearance.ALLOWED;
+			// Checks whether card is a wild card
+
+			return PlacementClearance.NEUTRAL;
+		}
+	}
+
+	/**
+	 * @return {@link UnoRulePack} of the official wild card placement rules
+	 */
+	public static UnoRulePack getPack() {
+		if (pack == null)
+			createPack();
+
+		return pack;
+	}
+
+}

--- a/src/main/java/com/github/markozajc/juno/rules/impl/WildPlacementRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/impl/WildPlacementRules.java
@@ -10,7 +10,9 @@ import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
  * Placement rules for {@link UnoWildCard}.
  *
  * @author Marko Zajc
+ * @deprecated Already defined in {@link ColorPlacementRules}
  */
+@Deprecated
 public class WildPlacementRules {
 
 	private WildPlacementRules() {}

--- a/src/main/java/com/github/markozajc/juno/rules/pack/UnoRulePack.java
+++ b/src/main/java/com/github/markozajc/juno/rules/pack/UnoRulePack.java
@@ -1,0 +1,5 @@
+package com.github.markozajc.juno.rules.pack;
+
+public class UnoRulePack {
+
+}

--- a/src/main/java/com/github/markozajc/juno/rules/pack/UnoRulePack.java
+++ b/src/main/java/com/github/markozajc/juno/rules/pack/UnoRulePack.java
@@ -52,9 +52,22 @@ public class UnoRulePack {
 	 */
 	@SuppressWarnings("null")
 	@Nonnull
-	public UnoRulePack ofPacks(@Nonnull Collection<UnoRulePack> packs) {
+	public static UnoRulePack ofPacks(@Nonnull Collection<UnoRulePack> packs) {
 		return new UnoRulePack(packs.stream().flatMap(p -> p.getRules().stream()).collect(Collectors.toList()));
 		// Lambda magic to flatten a list of UnoRulePack-s
+	}
+
+	/**
+	 * Creates a new {@link UnoRulePack} from a vararg of {@link UnoRulePack}s
+	 *
+	 * @param packs
+	 *            the {@link UnoRulePack}s
+	 * @return the combined {@link UnoRulePack}
+	 */
+	@SuppressWarnings("null")
+	@Nonnull
+	public static UnoRulePack ofPacks(@Nonnull UnoRulePack... packs) {
+		return ofPacks(Arrays.asList(packs));
 	}
 
 	/**

--- a/src/main/java/com/github/markozajc/juno/rules/pack/UnoRulePack.java
+++ b/src/main/java/com/github/markozajc/juno/rules/pack/UnoRulePack.java
@@ -1,5 +1,56 @@
 package com.github.markozajc.juno.rules.pack;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+
+import com.github.markozajc.juno.rules.UnoRule;
+
+/**
+ * A pack of {@link UnoRule}s. Multiple {@link UnoRulePack}s can be combined into one
+ * using {@link #ofPacks(Collection)}.
+ *
+ * @author Marko Zajc
+ */
 public class UnoRulePack {
+
+	@Nonnull
+	private final List<UnoRule> rules;
+
+	/**
+	 * Creates a new {@link UnoRulePack} from a {@link Collection} of {@link UnoRule}s
+	 *
+	 * @param rules
+	 *            the {@link UnoRule}s
+	 */
+	public UnoRulePack(@Nonnull Collection<UnoRule> rules) {
+		this.rules = new ArrayList<>(rules);
+	}
+
+	/**
+	 * Creates a new {@link UnoRulePack} from a {@link Collection} of
+	 * {@link UnoRulePack}s
+	 *
+	 * @param packs
+	 *            the {@link UnoRulePack}s
+	 * @return the combined {@link UnoRulePack}
+	 */
+	@SuppressWarnings("null")
+	@Nonnull
+	public UnoRulePack ofPacks(@Nonnull Collection<UnoRulePack> packs) {
+		return new UnoRulePack(packs.stream().flatMap(p -> p.getRules().stream()).collect(Collectors.toList()));
+		// Lambda magic to flatten a list of UnoRulePack-s
+	}
+
+	/**
+	 * @return this {@link UnoRulePack}'s rules
+	 */
+	@Nonnull
+	public List<UnoRule> getRules() {
+		return this.rules;
+	}
 
 }

--- a/src/main/java/com/github/markozajc/juno/rules/pack/UnoRulePack.java
+++ b/src/main/java/com/github/markozajc/juno/rules/pack/UnoRulePack.java
@@ -1,6 +1,7 @@
 package com.github.markozajc.juno.rules.pack;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,13 +22,23 @@ public class UnoRulePack {
 	private final List<UnoRule> rules;
 
 	/**
-	 * Creates a new {@link UnoRulePack} from a {@link Collection} of {@link UnoRule}s
+	 * Creates a new {@link UnoRulePack} from a {@link Collection} of {@link UnoRule}s.
 	 *
 	 * @param rules
 	 *            the {@link UnoRule}s
 	 */
 	public UnoRulePack(@Nonnull Collection<UnoRule> rules) {
 		this.rules = new ArrayList<>(rules);
+	}
+
+	/**
+	 * Creates a new {@link UnoRulePack} from a vararg of {@link UnoRule}s.
+	 *
+	 * @param rules
+	 *            the {@link UnoRule}s
+	 */
+	public UnoRulePack(@Nonnull UnoRule... rules) {
+		this(Arrays.asList(rules));
 	}
 
 	/**

--- a/src/main/java/com/github/markozajc/juno/rules/pack/UnoRulePack.java
+++ b/src/main/java/com/github/markozajc/juno/rules/pack/UnoRulePack.java
@@ -37,6 +37,7 @@ public class UnoRulePack {
 	 * @param rules
 	 *            the {@link UnoRule}s
 	 */
+	@SuppressWarnings("null")
 	public UnoRulePack(@Nonnull UnoRule... rules) {
 		this(Arrays.asList(rules));
 	}

--- a/src/main/java/com/github/markozajc/juno/rules/pack/impl/UnoOfficialRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/pack/impl/UnoOfficialRules.java
@@ -7,7 +7,6 @@ import com.github.markozajc.juno.rules.impl.ActionPlacementRules;
 import com.github.markozajc.juno.rules.impl.ColorPlacementRules;
 import com.github.markozajc.juno.rules.impl.DrawPlacementRules;
 import com.github.markozajc.juno.rules.impl.NumericPlacementRules;
-import com.github.markozajc.juno.rules.impl.WildPlacementRules;
 import com.github.markozajc.juno.rules.pack.UnoRulePack;
 
 /**
@@ -23,7 +22,7 @@ public class UnoOfficialRules {
 
 	private static void createPack() {
 		pack = UnoRulePack.ofPacks(ActionPlacementRules.getPack(), ColorPlacementRules.getPack(),
-			DrawPlacementRules.getPack(), NumericPlacementRules.getPack(), WildPlacementRules.getPack());
+			DrawPlacementRules.getPack(), NumericPlacementRules.getPack());
 	}
 
 	/**

--- a/src/main/java/com/github/markozajc/juno/rules/pack/impl/UnoOfficialRules.java
+++ b/src/main/java/com/github/markozajc/juno/rules/pack/impl/UnoOfficialRules.java
@@ -1,0 +1,41 @@
+package com.github.markozajc.juno.rules.pack.impl;
+
+import javax.annotation.Nonnull;
+
+import com.github.markozajc.juno.cards.impl.UnoDrawCard;
+import com.github.markozajc.juno.rules.impl.ActionPlacementRules;
+import com.github.markozajc.juno.rules.impl.ColorPlacementRules;
+import com.github.markozajc.juno.rules.impl.DrawPlacementRules;
+import com.github.markozajc.juno.rules.impl.NumericPlacementRules;
+import com.github.markozajc.juno.rules.impl.WildPlacementRules;
+import com.github.markozajc.juno.rules.pack.UnoRulePack;
+
+/**
+ * Placement rules for {@link UnoDrawCard}.
+ *
+ * @author Marko Zajc
+ */
+public class UnoOfficialRules {
+
+	private UnoOfficialRules() {}
+
+	private static UnoRulePack pack;
+
+	private static void createPack() {
+		pack = UnoRulePack.ofPacks(ActionPlacementRules.getPack(), ColorPlacementRules.getPack(),
+			DrawPlacementRules.getPack(), NumericPlacementRules.getPack(), WildPlacementRules.getPack());
+	}
+
+	/**
+	 * @return {@link UnoRulePack} of the official draw placement rules
+	 */
+	@SuppressWarnings("null")
+	@Nonnull
+	public static UnoRulePack getPack() {
+		if (pack == null)
+			createPack();
+
+		return pack;
+	}
+
+}

--- a/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
+++ b/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
@@ -1,0 +1,36 @@
+package com.github.markozajc.juno.rules.types;
+
+import java.util.Collection;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import com.github.markozajc.juno.cards.UnoCard;
+import com.github.markozajc.juno.hands.UnoHand;
+import com.github.markozajc.juno.piles.impl.UnoDiscardPile;
+import com.github.markozajc.juno.rules.UnoRule;
+
+/**
+ * A rule type that defines what cards can be placed on what.
+ *
+ * @author Marko Zajc
+ */
+public abstract class UnoCardPlacementRule extends UnoRule {
+
+	/**
+	 * Finds all possible cards that can be placed on a certain {@link UnoCard} from a
+	 * {@link Collection} of cards.
+	 *
+	 * @param target
+	 *            the target card (eg. the top {@link UnoCard} of the
+	 *            {@link UnoDiscardPile})
+	 * @param cards
+	 *            the {@link Collection} of cards to analyze (eg. {@link UnoHand}'s
+	 *            cards)
+	 * @return a {@link List} of all possible cards from {@code cards} can be placed on
+	 *         the {@code targetCard}.
+	 */
+	@Nonnull
+	public abstract <T extends UnoCard> Collection<T> analyzePossiblePlacements(@Nonnull UnoCard target, @Nonnull Collection<T> cards);
+
+}

--- a/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
+++ b/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
@@ -8,11 +8,11 @@ import com.github.markozajc.juno.piles.impl.UnoDiscardPile;
 import com.github.markozajc.juno.rules.UnoRule;
 
 /**
- * A rule type that defines what cards can be placed on what.
+ * A rule type that defines what {@link UnoCard} can be placed on what {@link UnoCard}.
  *
  * @author Marko Zajc
  */
-public abstract class UnoCardPlacementRule extends UnoRule {
+public interface UnoCardPlacementRule extends UnoRule {
 
 	/**
 	 * The placement clearance for a card that determines whether a card can be placed

--- a/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
+++ b/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
@@ -1,7 +1,5 @@
 package com.github.markozajc.juno.rules.types;
 
-import java.util.Collection;
-
 import javax.annotation.Nonnull;
 
 import com.github.markozajc.juno.cards.UnoCard;
@@ -58,8 +56,7 @@ public abstract class UnoCardPlacementRule extends UnoRule {
 	 *            the target card (eg. the top {@link UnoCard} of the
 	 *            {@link UnoDiscardPile})
 	 * @param card
-	 *            the {@link Collection} of cards to analyze (eg. {@link UnoHand}'s
-	 *            cards)
+	 *            the of card to check
 	 * @param hand
 	 *            the {@link UnoHand} placing the card
 	 * @return whether {@code card} can be placed atop of {@code target}. This should

--- a/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
+++ b/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
@@ -17,6 +17,30 @@ import com.github.markozajc.juno.rules.UnoRule;
 public abstract class UnoCardPlacementRule extends UnoRule {
 
 	/**
+	 * The placement clearance for a card that determines whether a card can be placed
+	 * atop of a card or not. The rules for deciding whether a card can be placed in a
+	 * multirule environment are as follows:
+	 * <ul>
+	 * <li>If all are NEUTRAL the card <b>can't be placed</b>
+	 * <li>If there are NEUTRAL but at there's least one ALLOWED the card <b>can be
+	 * placed</b>
+	 * <li>If all are ALLOWED the card <b>can be placed</b>
+	 * <li>If there are ALLOWED but there's at least one PROHIBITED the card <b>can't be
+	 * placed</b>
+	 * <li>If all are PROHIBITED <b>can't be placed</b>
+	 * </ul>
+	 *
+	 * @author Marko Zajc
+	 */
+	public enum PlacementClearance {
+
+		ALLOWED,
+		NEUTRAL,
+		PROHIBITED;
+
+	}
+
+	/**
 	 * Checks whether a certain card can be placed atop of a target card.
 	 *
 	 * @param target
@@ -25,8 +49,10 @@ public abstract class UnoCardPlacementRule extends UnoRule {
 	 * @param card
 	 *            the {@link Collection} of cards to analyze (eg. {@link UnoHand}'s
 	 *            cards)
+	 * @param hand
+	 *            the {@link UnoHand} placing the card
 	 * @return whether {@code card} can be placed atop of {@code target}
 	 */
-	public abstract boolean canBePlaced(@Nonnull UnoCard target, @Nonnull UnoCard card);
+	public abstract PlacementClearance canBePlaced(@Nonnull UnoCard target, @Nonnull UnoCard card, @Nonnull UnoHand hand);
 
 }

--- a/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
+++ b/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
@@ -1,7 +1,6 @@
 package com.github.markozajc.juno.rules.types;
 
 import java.util.Collection;
-import java.util.List;
 
 import javax.annotation.Nonnull;
 
@@ -18,19 +17,16 @@ import com.github.markozajc.juno.rules.UnoRule;
 public abstract class UnoCardPlacementRule extends UnoRule {
 
 	/**
-	 * Finds all possible cards that can be placed on a certain {@link UnoCard} from a
-	 * {@link Collection} of cards.
+	 * Checks whether a certain card can be placed atop of a target card.
 	 *
 	 * @param target
 	 *            the target card (eg. the top {@link UnoCard} of the
 	 *            {@link UnoDiscardPile})
-	 * @param cards
+	 * @param card
 	 *            the {@link Collection} of cards to analyze (eg. {@link UnoHand}'s
 	 *            cards)
-	 * @return a {@link List} of all possible cards from {@code cards} can be placed on
-	 *         the {@code targetCard}.
+	 * @return whether {@code card} can be placed atop of {@code target}
 	 */
-	@Nonnull
-	public abstract <T extends UnoCard> Collection<T> analyzePossiblePlacements(@Nonnull UnoCard target, @Nonnull Collection<T> cards);
+	public abstract boolean canBePlaced(@Nonnull UnoCard target, @Nonnull UnoCard card);
 
 }

--- a/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
+++ b/src/main/java/com/github/markozajc/juno/rules/types/UnoCardPlacementRule.java
@@ -34,8 +34,19 @@ public abstract class UnoCardPlacementRule extends UnoRule {
 	 */
 	public enum PlacementClearance {
 
+		/**
+		 * The cards may be placed on each other (for example Blue 1 on Blue 2)
+		 */
 		ALLOWED,
+		/**
+		 * That is out of this rule's field (for example Blue 1 on Green draw two)
+		 */
 		NEUTRAL,
+		/**
+		 * The cards must not be placed atop of each other (for example Wild draw four while
+		 * its holder has a card that's the color of the top card - the extra hitch to the
+		 * Wild draw four that's in the official UNO rules)
+		 */
 		PROHIBITED;
 
 	}
@@ -51,7 +62,13 @@ public abstract class UnoCardPlacementRule extends UnoRule {
 	 *            cards)
 	 * @param hand
 	 *            the {@link UnoHand} placing the card
-	 * @return whether {@code card} can be placed atop of {@code target}
+	 * @return whether {@code card} can be placed atop of {@code target}. This should
+	 *         return ALLOWED if the cards may be placed atop of each other (for example
+	 *         Blue 1 on Blue 2), NEUTRAL if that is out of this rule's field (for
+	 *         example Blue 1 on Green draw two) and PROHOBITED if the cards must not be
+	 *         placed atop of each other (for example Wild draw four while its holder has
+	 *         a card that's the color of the top card - the extra hitch to the Wild draw
+	 *         four that's in the official UNO rules)
 	 */
 	public abstract PlacementClearance canBePlaced(@Nonnull UnoCard target, @Nonnull UnoCard card, @Nonnull UnoHand hand);
 

--- a/src/main/java/com/github/markozajc/juno/utils/UnoRuleUtils.java
+++ b/src/main/java/com/github/markozajc/juno/utils/UnoRuleUtils.java
@@ -1,5 +1,6 @@
 package com.github.markozajc.juno.utils;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -7,9 +8,11 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import com.github.markozajc.juno.cards.UnoCard;
+import com.github.markozajc.juno.hands.UnoHand;
 import com.github.markozajc.juno.rules.UnoRule;
 import com.github.markozajc.juno.rules.pack.UnoRulePack;
 import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
+import com.github.markozajc.juno.rules.types.UnoCardPlacementRule.PlacementClearance;
 
 public class UnoRuleUtils {
 
@@ -17,19 +20,23 @@ public class UnoRuleUtils {
 
 	@SuppressWarnings("null")
 	@Nonnull
-	public static List<UnoCard> combinedPlacementAnalysis(@Nonnull UnoCard target, @Nonnull Collection<UnoCard> cards, @Nonnull UnoRulePack pack) {
+	public static List<UnoCard> combinedPlacementAnalysis(@Nonnull UnoCard target, @Nonnull Collection<UnoCard> cards, @Nonnull UnoRulePack pack, @Nonnull UnoHand hand) {
 		List<UnoCardPlacementRule> rules = filterRuleKind(pack.getRules(), UnoCardPlacementRule.class);
-		return cards.stream() /* 1 */
-				.filter(c -> rules.stream()
-						/* 2 */.map(r -> r.canBePlaced(target, c, null))
-						/* 3 */.filter(v -> v)
-						/* 4 */.count() > 0/* 5 */)
-				.collect(Collectors.toList()); /* 6 */
-		// Lambda magic
-		// Basically iterates over the cards (1), then iterates over the placement rules for
-		// each card (2), maps all rules' return values to a stream of booleans (3), filters
-		// out the falses (4) and checks if there are any elements in the filtered stream
-		// (5), then collects the stream into a list (6)
+		List<UnoCard> result = new ArrayList<>();
+
+		for (UnoCard card : cards) {
+			// Iterates over all cards
+			List<PlacementClearance> clearance = rules.stream()
+					.map(r -> r.canBePlaced(target, card, hand))
+					.collect(Collectors.toList());
+			// Gets the PlacementClearance-s for this card
+
+			if (clearance.contains(PlacementClearance.ALLOWED) && !clearance.contains(PlacementClearance.PROHIBITED))
+				result.add(card);
+			// Adds the card if allowed
+		}
+
+		return result;
 	}
 
 	@SuppressWarnings("null")

--- a/src/main/java/com/github/markozajc/juno/utils/UnoRuleUtils.java
+++ b/src/main/java/com/github/markozajc/juno/utils/UnoRuleUtils.java
@@ -1,0 +1,34 @@
+package com.github.markozajc.juno.utils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+
+import com.github.markozajc.juno.cards.UnoCard;
+import com.github.markozajc.juno.rules.UnoRule;
+import com.github.markozajc.juno.rules.pack.UnoRulePack;
+import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
+
+public class UnoRuleUtils {
+
+	private UnoRuleUtils() {}
+
+	@SuppressWarnings("null")
+	@Nonnull
+	public static List<UnoCard> combinedPlacementAnalysis(@Nonnull UnoCard target, @Nonnull Collection<UnoCard> cards, @Nonnull UnoRulePack pack) {
+		return filterRuleKind(pack.getRules(), UnoCardPlacementRule.class).stream()
+				.flatMap(r -> r.analyzePossiblePlacements(target, cards).stream())
+				.distinct()
+				.collect(Collectors.toList());
+		// Lambda magic
+	}
+
+	@SuppressWarnings("null")
+	@Nonnull
+	public static <T extends UnoRule> List<T> filterRuleKind(@Nonnull List<UnoRule> rules, @Nonnull Class<T> kind) {
+		return rules.stream().filter(kind::isInstance).map(kind::cast).collect(Collectors.toList());
+	}
+
+}

--- a/src/main/java/com/github/markozajc/juno/utils/UnoRuleUtils.java
+++ b/src/main/java/com/github/markozajc/juno/utils/UnoRuleUtils.java
@@ -14,10 +14,31 @@ import com.github.markozajc.juno.rules.pack.UnoRulePack;
 import com.github.markozajc.juno.rules.types.UnoCardPlacementRule;
 import com.github.markozajc.juno.rules.types.UnoCardPlacementRule.PlacementClearance;
 
+/**
+ * {@link UnoRule}-specific utilities.
+ *
+ * @author Marko Zajc
+ */
 public class UnoRuleUtils {
 
 	private UnoRuleUtils() {}
 
+	/**
+	 * Filters a {@link Collection} of {@link UnoCard}s to determine which can be placed
+	 * on the {@code target} {@link UnoCard}. The deciding factor here is the
+	 * {@link UnoRulePack}, specifically the {@link UnoCardPlacementRule}s in it.
+	 *
+	 * @param target
+	 *            the target (top of the discard) {@link UnoCard}
+	 * @param cards
+	 *            {@link Collection} of {@link UnoCard}s to filter through
+	 * @param pack
+	 *            the {@link UnoRulePack} to use
+	 * @param hand
+	 *            the {@link UnoHand} filtering the cards
+	 * @return a {@link List} of {@link UnoCard}s that can be placed atop of the
+	 *         {@code target} {@link UnoCard}
+	 */
 	@SuppressWarnings("null")
 	@Nonnull
 	public static List<UnoCard> combinedPlacementAnalysis(@Nonnull UnoCard target, @Nonnull Collection<UnoCard> cards, @Nonnull UnoRulePack pack, @Nonnull UnoHand hand) {
@@ -39,9 +60,21 @@ public class UnoRuleUtils {
 		return result;
 	}
 
+	/**
+	 * Filters a {@link Collection} of {@link UnoRule}s by their kind.
+	 *
+	 * @param <T>
+	 *            kind of the {@link UnoRule} to search for
+	 * @param rules
+	 *            {@link Collection} of {@link UnoRule}s to filter
+	 * @param kind
+	 *            kind of the {@link UnoRule} to search for (a {@link Class}, required by
+	 *            Java to cast objects).
+	 * @return a {@link List} containing the requested kind of {@link UnoRule}s
+	 */
 	@SuppressWarnings("null")
 	@Nonnull
-	public static <T extends UnoRule> List<T> filterRuleKind(@Nonnull List<UnoRule> rules, @Nonnull Class<T> kind) {
+	public static <T extends UnoRule> List<T> filterRuleKind(@Nonnull Collection<UnoRule> rules, @Nonnull Class<T> kind) {
 		return rules.stream().filter(kind::isInstance).map(kind::cast).collect(Collectors.toList());
 	}
 

--- a/src/main/java/com/github/markozajc/juno/utils/UnoRuleUtils.java
+++ b/src/main/java/com/github/markozajc/juno/utils/UnoRuleUtils.java
@@ -18,11 +18,18 @@ public class UnoRuleUtils {
 	@SuppressWarnings("null")
 	@Nonnull
 	public static List<UnoCard> combinedPlacementAnalysis(@Nonnull UnoCard target, @Nonnull Collection<UnoCard> cards, @Nonnull UnoRulePack pack) {
-		return filterRuleKind(pack.getRules(), UnoCardPlacementRule.class).stream()
-				.flatMap(r -> r.analyzePossiblePlacements(target, cards).stream())
-				.distinct()
-				.collect(Collectors.toList());
+		List<UnoCardPlacementRule> rules = filterRuleKind(pack.getRules(), UnoCardPlacementRule.class);
+		return cards.stream() /* 1 */
+				.filter(c -> rules.stream()
+						/* 2 */.map(r -> r.canBePlaced(target, c))
+						/* 3 */.filter(v -> v)
+						/* 4 */.count() > 0/* 5 */)
+				.collect(Collectors.toList()); /* 6 */
 		// Lambda magic
+		// Basically iterates over the cards (1), then iterates over the placement rules for
+		// each card (2), maps all rules' return values to a stream of booleans (3), filters
+		// out the falses (4) and checks if there are any elements in the filtered stream
+		// (5), then collects the stream into a list (6)
 	}
 
 	@SuppressWarnings("null")

--- a/src/main/java/com/github/markozajc/juno/utils/UnoRuleUtils.java
+++ b/src/main/java/com/github/markozajc/juno/utils/UnoRuleUtils.java
@@ -21,7 +21,7 @@ public class UnoRuleUtils {
 		List<UnoCardPlacementRule> rules = filterRuleKind(pack.getRules(), UnoCardPlacementRule.class);
 		return cards.stream() /* 1 */
 				.filter(c -> rules.stream()
-						/* 2 */.map(r -> r.canBePlaced(target, c))
+						/* 2 */.map(r -> r.canBePlaced(target, c, null))
 						/* 3 */.filter(v -> v)
 						/* 4 */.count() > 0/* 5 */)
 				.collect(Collectors.toList()); /* 6 */

--- a/src/main/java/com/github/markozajc/juno/utils/UnoUtils.java
+++ b/src/main/java/com/github/markozajc/juno/utils/UnoUtils.java
@@ -43,6 +43,7 @@ public class UnoUtils {
 	 * @return a {@link List} of all possible cards from {@code cards} can be placed on
 	 *         the {@code targetCard}.
 	 */
+	@Deprecated
 	public static List<UnoCard> analyzePossibleCards(UnoCard targetCard, Collection<UnoCard> cards) {
 		List<UnoCard> result = new ArrayList<>();
 

--- a/src/main/java/com/github/markozajc/juno/utils/UnoUtils.java
+++ b/src/main/java/com/github/markozajc/juno/utils/UnoUtils.java
@@ -34,14 +34,21 @@ public class UnoUtils {
 	 * {@link List} of cards. This implements all standard UNO rules (same color for all
 	 * {@link UnoCard}s, same number for all {@link UnoNumericCard}s or same action for
 	 * {@link UnoActionCard}) as well as the progressive UNO rule (same quantity for
-	 * {@link UnoDrawCard}s). This is intended to be utilized by {@link UnoHand}s to be able
-	 * to decide between their available cards better and more easily and by
+	 * {@link UnoDrawCard}s). This is intended to be utilized by {@link UnoHand}s to be
+	 * able to decide between their available cards better and more easily and by
 	 * {@link UnoGame} implementations to prevent cheating - accidental or not.
 	 *
-	 * @param targetCard the target card (eg. the top {@link UnoCard} of the {@link UnoDiscardPile})
-	 * @param cards the {@link Collection} of cards to analyze (eg. {@link UnoHand}'s cards)
+	 * @param targetCard
+	 *            the target card (eg. the top {@link UnoCard} of the
+	 *            {@link UnoDiscardPile})
+	 * @param cards
+	 *            the {@link Collection} of cards to analyze (eg. {@link UnoHand}'s
+	 *            cards)
 	 * @return a {@link List} of all possible cards from {@code cards} can be placed on
 	 *         the {@code targetCard}.
+	 * @deprecated This method only supports a hard-coded set of rules. Use
+	 *             {@link UnoRuleUtils#combinedPlacementAnalysis(UnoCard, Collection, com.github.markozajc.juno.rules.pack.UnoRulePack, UnoHand)}
+	 *             instead.
 	 */
 	@Deprecated
 	public static List<UnoCard> analyzePossibleCards(UnoCard targetCard, Collection<UnoCard> cards) {
@@ -61,10 +68,9 @@ public class UnoUtils {
 		// case the other player placed a draw card (a progressive UNO thing, similar to the
 		// "check" state in Chess)
 
-		if(targetCard instanceof UnoWildCard && targetCard.getColor().equals(UnoCardColor.WILD))
+		if (targetCard instanceof UnoWildCard && targetCard.getColor().equals(UnoCardColor.WILD))
 			return Collections.emptyList();
 		// No card can be placed on an unset wild card
-
 
 		if (targetCard instanceof UnoNumericCard) {
 			UnoNumericCard castTop = (UnoNumericCard) targetCard;

--- a/src/test/java/com/github/markozajc/juno/TestUtils.java
+++ b/src/test/java/com/github/markozajc/juno/TestUtils.java
@@ -3,6 +3,13 @@ package com.github.markozajc.juno;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
+
+import com.github.markozajc.juno.cards.UnoCard;
+import com.github.markozajc.juno.cards.UnoCardColor;
+import com.github.markozajc.juno.game.UnoGame;
+import com.github.markozajc.juno.hands.UnoHand;
+
 /**
  * This is not actually a test class. Instead it provides shared utility methods to
  * the tests themselves.
@@ -11,19 +18,48 @@ import java.util.stream.Collectors;
  */
 public class TestUtils {
 
+	private static class UnoDummyHand extends UnoHand {
+
+		public UnoDummyHand(Collection<UnoCard> cards) {
+			super("Dummy Hand");
+			this.cards.addAll(cards);
+		}
+
+		@Override
+		public UnoCard playCard(UnoGame game, boolean drawn) {
+			return this.getCards().get(0);
+		}
+
+		@Override
+		public UnoCardColor chooseColor(UnoGame game) {
+			return UnoCardColor.RED;
+		}
+
+	}
+
 	/**
 	 * Checks the equality of two {@link Collection}s in an unordered manner.
 	 *
-	 * @param <T> collection item type
-	 * @param collection1 collection number one
-	 * @param collection2 collection number two
+	 * @param <T>
+	 *            collection item type
+	 * @param collection1
+	 *            collection number one
+	 * @param collection2
+	 *            collection number two
 	 * @return whether the collection contain equal items or not
 	 */
 	public static <T> boolean listEqualsUnordered(Collection<? extends T> collection1, Collection<? extends T> collection2) {
 		System.out.println("[= COMPARING COLLECTIONS /unordered =]");
-		System.out.println("Collection 1: " + collection1.stream().map(Object::toString).collect(Collectors.joining(",")));
-		System.out.println("Collection 2: " + collection2.stream().map(Object::toString).collect(Collectors.joining(",")));
+		System.out.println(
+			"Collection 1: " + collection1.stream().map(Object::toString).collect(Collectors.joining(",")));
+		System.out.println(
+			"Collection 2: " + collection2.stream().map(Object::toString).collect(Collectors.joining(",")));
 		return collection1.size() == collection2.size() && collection1.containsAll(collection2);
+	}
+
+	@Nonnull
+	public static UnoHand getDummyHand(Collection<UnoCard> cards) {
+		return new UnoDummyHand(cards);
 	}
 
 }

--- a/src/test/java/com/github/markozajc/juno/TestUtils.java
+++ b/src/test/java/com/github/markozajc/juno/TestUtils.java
@@ -1,12 +1,14 @@
 package com.github.markozajc.juno;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
 import com.github.markozajc.juno.cards.UnoCard;
 import com.github.markozajc.juno.cards.UnoCardColor;
+import com.github.markozajc.juno.decks.UnoDeck;
 import com.github.markozajc.juno.game.UnoGame;
 import com.github.markozajc.juno.hands.UnoHand;
 
@@ -18,23 +20,44 @@ import com.github.markozajc.juno.hands.UnoHand;
  */
 public class TestUtils {
 
-	private static class UnoDummyHand extends UnoHand {
+	private static class DummyUnoHand extends UnoHand {
 
-		public UnoDummyHand(Collection<UnoCard> cards) {
+		public DummyUnoHand(@Nonnull Collection<UnoCard> cards) {
 			super("Dummy Hand");
 			this.cards.addAll(cards);
 		}
 
 		@Override
 		public UnoCard playCard(UnoGame game, boolean drawn) {
-			return this.getCards().get(0);
+			throw new UnsupportedOperationException("DummyUnoHand can not play cards.");
 		}
 
 		@Override
 		public UnoCardColor chooseColor(UnoGame game) {
-			return UnoCardColor.RED;
+			throw new UnsupportedOperationException("DummyUnoHand can not choose colors.");
 		}
 
+	}
+
+	private static class DummyUnoDeck implements UnoDeck {
+
+		@Nonnull
+		private final List<UnoCard> cards;
+
+		public DummyUnoDeck(@Nonnull List<UnoCard> cards) {
+			this.cards = cards;
+		}
+
+		@Override
+		public int getExpectedSize() {
+			return this.cards.size();
+		}
+
+		@Override
+		public List<UnoCard> getCards() {
+			return this.cards;
+			// Doesn't actually make a clone. A production deck should always make a clone here.
+		}
 	}
 
 	/**
@@ -57,9 +80,34 @@ public class TestUtils {
 		return collection1.size() == collection2.size() && collection1.containsAll(collection2);
 	}
 
+	/**
+	 * Returns a dummy {@link UnoDeck} containing a preferred {@link Collection} of
+	 * cards. Calling either {@link UnoHand#playCard(UnoGame, boolean)} or
+	 * {@link UnoHand#chooseColor(UnoGame)} will throw an
+	 * {@link UnsupportedOperationException}.
+	 *
+	 * @param cards
+	 *            {@link Collection} of {@link UnoCard}s the {@link UnoHand} should
+	 *            contain
+	 * @return the created {@link UnoHand}
+	 */
 	@Nonnull
-	public static UnoHand getDummyHand(Collection<UnoCard> cards) {
-		return new UnoDummyHand(cards);
+	public static UnoHand getDummyHand(@Nonnull Collection<UnoCard> cards) {
+		return new DummyUnoHand(cards);
+	}
+
+	/**
+	 * Returns a dummy {@link UnoDeck} containing a preferred {@link List} of cards.
+	 * {@link UnoDeck#getExpectedSize()} will contain the size of the provided
+	 * {@link List}.
+	 *
+	 * @param cards
+	 *            {@link List} of {@link UnoCard}s the {@link UnoDeck} should contain
+	 * @return the built {@link UnoDeck}
+	 */
+	@Nonnull
+	public static UnoDeck getDummyDeck(@Nonnull List<UnoCard> cards) {
+		return new DummyUnoDeck(cards);
 	}
 
 }

--- a/src/test/java/com/github/markozajc/juno/piles/impl/UnoDrawPileTest.java
+++ b/src/test/java/com/github/markozajc/juno/piles/impl/UnoDrawPileTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import com.github.markozajc.juno.TestUtils;
 import com.github.markozajc.juno.cards.UnoCard;
 import com.github.markozajc.juno.cards.UnoCardColor;
 import com.github.markozajc.juno.cards.UnoStandardDeck;
@@ -27,26 +27,14 @@ class UnoDrawPileTest {
 
 		assertEquals(deck.getExpectedSize(), pile.getSize());
 		// Checks whether the deck and the pile are of the same size
-}
+	}
 
+	@SuppressWarnings("null")
 	@Test
 	void testShuffle() {
-		UnoDeck deck = new UnoDeck() {
-
-			@Override
-			public int getExpectedSize() {
-				return 4;
-			}
-
-			@SuppressWarnings("null")
-			@Override
-			public List<UnoCard> getCards() {
-				return Arrays.asList(new UnoNumericCard(0, UnoCardColor.RED), new UnoNumericCard(1, UnoCardColor.GREEN),
-					new UnoNumericCard(2, UnoCardColor.BLUE), new UnoNumericCard(3, UnoCardColor.YELLOW));
-				// Doesn't actually make a clone because we need the list to be equal. A production
-				// deck should always make a clone here.
-			}
-		};
+		UnoDeck deck = TestUtils.getDummyDeck(
+			Arrays.asList(new UnoNumericCard(0, UnoCardColor.RED), new UnoNumericCard(1, UnoCardColor.GREEN),
+				new UnoNumericCard(2, UnoCardColor.BLUE), new UnoNumericCard(3, UnoCardColor.YELLOW)));
 		// Creates a new dummy deck
 
 		UnoDrawPile pile = new UnoDrawPile(deck);

--- a/src/test/java/com/github/markozajc/juno/utils/UnoRuleUtilsTest.java
+++ b/src/test/java/com/github/markozajc/juno/utils/UnoRuleUtilsTest.java
@@ -1,16 +1,173 @@
 package com.github.markozajc.juno.utils;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
+import com.github.markozajc.juno.TestUtils;
+import com.github.markozajc.juno.cards.UnoCard;
+import com.github.markozajc.juno.cards.UnoCardColor;
+import com.github.markozajc.juno.cards.impl.UnoActionCard;
+import com.github.markozajc.juno.cards.impl.UnoActionCard.UnoAction;
+import com.github.markozajc.juno.cards.impl.UnoDrawCard;
+import com.github.markozajc.juno.cards.impl.UnoNumericCard;
+import com.github.markozajc.juno.cards.impl.UnoWildCard;
+import com.github.markozajc.juno.hands.UnoHand;
+import com.github.markozajc.juno.rules.pack.UnoRulePack;
+import com.github.markozajc.juno.rules.pack.impl.UnoOfficialRules;
 
 class UnoRuleUtilsTest {
 
+	@SuppressWarnings("null")
 	@Test
 	void testAnalyzePossibleCards() {
-		fail("TODO");
+		UnoRulePack pack = UnoOfficialRules.getPack();
+
+		UnoCard[] cards = new UnoCard[] {
+				/* 0 */ new UnoNumericCard(0, UnoCardColor.BLUE),
+				/* 1 */ new UnoNumericCard(0, UnoCardColor.RED),
+				/* 2 */ new UnoNumericCard(1, UnoCardColor.YELLOW),
+				/* 3 */ new UnoNumericCard(1, UnoCardColor.BLUE),
+				/* 4 */ new UnoWildCard(),
+				/* 5 */ new UnoDrawCard(),
+				/* 6 */ new UnoDrawCard(UnoCardColor.BLUE),
+				/* 7 */ new UnoDrawCard(UnoCardColor.RED),
+				/* 8 */ new UnoActionCard(UnoAction.SKIP, UnoCardColor.YELLOW),
+				/* 9 */ new UnoActionCard(UnoAction.REVERSE, UnoCardColor.GREEN),
+				/* 10 */ new UnoActionCard(UnoAction.REVERSE, UnoCardColor.BLUE)
+
+		};
+		// Creates a list of cards to be tested
+		/*
+		 * Cards: Blue 0, Red 0, Yellow 1, Blue 1, Wild, Draw four, Blue draw two, Red draw
+		 * two, Yellow skip, Green reverse, Blue reverse
+		 */
+
+		UnoHand hand = TestUtils.getDummyHand(Arrays.asList(cards[0]));
+
+		assertTrue(TestUtils.listEqualsUnordered(
+			UnoRuleUtils.combinedPlacementAnalysis(cards[0], Arrays.asList(cards), pack, hand),
+			Arrays.asList(cards[0], cards[1], cards[3], cards[4], cards[6], cards[10])));
+		// Pack: official
+		// Card: Blue 0 <0>
+		/*
+		 * Expected: Blue 0, Red 0, Blue 1, Wild, Blue draw two, Blue reverse
+		 */
+
+		assertTrue(TestUtils.listEqualsUnordered(
+			UnoRuleUtils.combinedPlacementAnalysis(cards[1], Arrays.asList(cards), pack, hand),
+			Arrays.asList(cards[0], cards[1], cards[4], cards[5], cards[7])));
+		// Pack: official
+		// Card: Red 0 <1>
+		/*
+		 * Expected: Blue 0, Red 0, Wild, Draw four, Red draw two
+		 */
+
+		assertTrue(TestUtils.listEqualsUnordered(
+			UnoRuleUtils.combinedPlacementAnalysis(cards[2], Arrays.asList(cards), pack, hand),
+			Arrays.asList(cards[2], cards[3], cards[4], cards[5], cards[8])));
+		// Pack: official
+		// Card: Yellow 1 <2>
+		/*
+		 * Expected: Yellow 1, Blue 1, Wild, Draw four, Yellow skip
+		 */
+
+		assertTrue(TestUtils.listEqualsUnordered(
+			UnoRuleUtils.combinedPlacementAnalysis(cards[3], Arrays.asList(cards), pack, hand),
+			Arrays.asList(cards[0], cards[2], cards[3], cards[4], cards[6], cards[10])));
+		// Pack: official
+		// Card: Blue 1 <3>
+		/*
+		 * Expected: Blue 0, Yellow 1, Blue 1, Wild, Blue draw two, Blue reverse
+		 */
+
+		assertTrue(TestUtils.listEqualsUnordered(
+			UnoRuleUtils.combinedPlacementAnalysis(cards[4], Arrays.asList(cards), pack, hand),
+			Arrays.asList(cards[4], cards[5])));
+		// Pack: official
+		// Card: Wild <4>
+		/*
+		 * Expected: Wild, Draw four
+		 */
+
+		assertTrue(TestUtils.listEqualsUnordered(
+			UnoRuleUtils.combinedPlacementAnalysis(cards[5], Arrays.asList(cards), pack, hand),
+			Collections.emptyList()));
+		// Pack: official
+		// Card: Draw four (unplayed) <5>
+		/*
+		 * Expected: (none)
+		 */
+
+		assertTrue(TestUtils.listEqualsUnordered(
+			UnoRuleUtils.combinedPlacementAnalysis(cards[6], Arrays.asList(cards), pack, hand),
+			Collections.emptyList()));
+		// Pack: official
+		// Card: Blue draw two (unplayed) <6>
+		/*
+		 * Expected: (none)
+		 */
+
+		assertTrue(TestUtils.listEqualsUnordered(
+			UnoRuleUtils.combinedPlacementAnalysis(cards[7], Arrays.asList(cards), pack, hand),
+			Collections.emptyList()));
+		// Pack: official
+		// Card: Red draw two (unplayed) <7>
+		/*
+		 * Expected: (none)
+		 */
+
+		assertTrue(TestUtils.listEqualsUnordered(
+			UnoRuleUtils.combinedPlacementAnalysis(cards[8], Arrays.asList(cards), pack, hand),
+			Arrays.asList(cards[2], cards[4], cards[5], cards[8])));
+		// Pack: official
+		// Card: Yellow skip <8>
+		/*
+		 * Expected: Yellow 1, Wild, Wild draw four, Yellow skip
+		 */
+
+		assertTrue(TestUtils.listEqualsUnordered(
+			UnoRuleUtils.combinedPlacementAnalysis(cards[9], Arrays.asList(cards), pack, hand),
+			Arrays.asList(cards[4], cards[5], cards[9], cards[10])));
+		// Pack: official
+		// Card: Green reverse <9>
+		/*
+		 * Expected: Wild, Draw four, Green reverse, Blue reverse
+		 */
+
+		assertTrue(TestUtils.listEqualsUnordered(
+			UnoRuleUtils.combinedPlacementAnalysis(cards[10], Arrays.asList(cards), pack, hand),
+			Arrays.asList(cards[0], cards[3], cards[4], cards[6], cards[9], cards[10])));
+		// Pack: official
+		// Card: Blue reverse <10>
+		/*
+		 * Expected: Blue 0, Blue 1, Wild, Blue draw two, Green reverse, Blue reverse
+		 */
+
 		// TODO
+		// Pack: official, progressive
+		// Card: Draw four (unplayed) <5>
+		/*
+		 * Expected: Draw four
+		 */
+
+		// TODO
+		// Pack: official, progressive
+		// Card: Blue draw two (unplayed) <6>
+		/*
+		 * Expected: Blue draw two, Red draw two
+		 */
+
+		// TODO
+		// Pack: official
+		// Card: Red draw two (unplayed) <7>
+		/*
+		 * Expected: Blue draw two, Red draw two
+		 */
+
 	}
 
 }

--- a/src/test/java/com/github/markozajc/juno/utils/UnoRuleUtilsTest.java
+++ b/src/test/java/com/github/markozajc/juno/utils/UnoRuleUtilsTest.java
@@ -1,0 +1,16 @@
+package com.github.markozajc.juno.utils;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+
+class UnoRuleUtilsTest {
+
+	@Test
+	void testAnalyzePossibleCards() {
+		fail("TODO");
+		// TODO
+	}
+
+}

--- a/src/test/java/com/github/markozajc/juno/utils/UnoUtilsTest.java
+++ b/src/test/java/com/github/markozajc/juno/utils/UnoUtilsTest.java
@@ -1,4 +1,4 @@
-package com.github.markozajc.juno;
+package com.github.markozajc.juno.utils;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -9,6 +9,7 @@ import java.util.Map.Entry;
 
 import org.junit.jupiter.api.Test;
 
+import com.github.markozajc.juno.TestUtils;
 import com.github.markozajc.juno.cards.UnoCard;
 import com.github.markozajc.juno.cards.UnoCardColor;
 import com.github.markozajc.juno.cards.impl.UnoActionCard;

--- a/src/test/java/com/github/markozajc/juno/utils/UnoUtilsTest.java
+++ b/src/test/java/com/github/markozajc/juno/utils/UnoUtilsTest.java
@@ -3,7 +3,6 @@ package com.github.markozajc.juno.utils;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -17,7 +16,6 @@ import com.github.markozajc.juno.cards.impl.UnoActionCard.UnoAction;
 import com.github.markozajc.juno.cards.impl.UnoDrawCard;
 import com.github.markozajc.juno.cards.impl.UnoNumericCard;
 import com.github.markozajc.juno.cards.impl.UnoWildCard;
-import com.github.markozajc.juno.utils.UnoUtils;
 
 class UnoUtilsTest {
 
@@ -27,105 +25,6 @@ class UnoUtilsTest {
 		System.out.println("< color  > " + entry.getValue() + " : " + expectedColor);
 
 		return entry.getKey() == expectedQuantity && entry.getValue().equals(expectedColor);
-	}
-
-	@Test
-	void testAnalyzePossibleCards() {
-		UnoCard[] cards = new UnoCard[] {
-				/* 0 */ new UnoNumericCard(0, UnoCardColor.BLUE),
-				/* 1 */ new UnoNumericCard(0, UnoCardColor.RED),
-				/* 2 */ new UnoNumericCard(1, UnoCardColor.YELLOW),
-				/* 3 */ new UnoNumericCard(1, UnoCardColor.BLUE),
-				/* 4 */ new UnoWildCard(),
-				/* 5 */ new UnoDrawCard(),
-				/* 6 */ new UnoDrawCard(UnoCardColor.BLUE),
-				/* 7 */ new UnoDrawCard(UnoCardColor.RED),
-				/* 8 */ new UnoActionCard(UnoAction.SKIP, UnoCardColor.YELLOW),
-				/* 9 */ new UnoActionCard(UnoAction.REVERSE, UnoCardColor.GREEN),
-				/* 10 */ new UnoActionCard(UnoAction.REVERSE, UnoCardColor.BLUE)
-
-		};
-
-		/*
-		 * Cards: Blue 0, Red 0, Yellow 1, Blue 1, Wild, Draw four, Blue draw two, Red draw
-		 * two, Yellow skip, Green reverse, Blue reverse
-		 */
-
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.analyzePossibleCards(cards[0], Arrays.asList(cards)),
-			Arrays.asList(cards[0], cards[1], cards[3], cards[4], cards[5], cards[6], cards[10])));
-		// Card: Blue 0 <0>
-		/*
-		 * Expected: Blue 0, Red 0, Blue 1, Wild, Draw four, Blue draw two, Blue reverse
-		 */
-
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.analyzePossibleCards(cards[1], Arrays.asList(cards)),
-			Arrays.asList(cards[0], cards[1], cards[4], cards[5], cards[7])));
-		// Card: Red 0 <1>
-		/*
-		 * Expected: Blue 0, Red 0, Wild, Draw four, Red draw two
-		 */
-
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.analyzePossibleCards(cards[2], Arrays.asList(cards)),
-			Arrays.asList(cards[2], cards[3], cards[4], cards[5], cards[8])));
-		// Card: Yellow 1 <2>
-		/*
-		 * Expected: Yellow 1, Blue 1, Wild, Draw four, Yellow skip
-		 */
-
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.analyzePossibleCards(cards[3], Arrays.asList(cards)),
-			Arrays.asList(cards[0], cards[2], cards[3], cards[4], cards[5], cards[6], cards[10])));
-		// Card: Blue 1 <3>
-		/*
-		 * Expected: Blue 0, Yellow 1, Blue 1, Wild, Draw four, Blue draw two, Blue reverse
-		 */
-
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.analyzePossibleCards(cards[4], Arrays.asList(cards)), Collections.emptyList()));
-		// Card: Wild <4>
-		/*
-		 * Expected: (none)
-		 */
-
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.analyzePossibleCards(cards[5], Arrays.asList(cards)), Arrays.asList(cards[5])));
-		// Card: Draw four (unplayed) <5>
-		/*
-		 * Expected: Draw four
-		 */
-
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.analyzePossibleCards(cards[6], Arrays.asList(cards)),
-			Arrays.asList(cards[6], cards[7])));
-		// Card: Blue draw two (unplayed) <6>
-		/*
-		 * Expected: Blue draw two, Red draw two
-		 */
-
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.analyzePossibleCards(cards[7], Arrays.asList(cards)),
-			Arrays.asList(cards[6], cards[7])));
-		// Card: Red draw two (unplayed) <7>
-		/*
-		 * Expected: Blue draw two, Red draw two
-		 */
-
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.analyzePossibleCards(cards[8], Arrays.asList(cards)),
-			Arrays.asList(cards[2], cards[4], cards[5], cards[8])));
-		// Card: Yellow skip <8>
-		/*
-		 * Expected: Yellow 1, Wild, Wild draw four, Yellow skip
-		 */
-
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.analyzePossibleCards(cards[9], Arrays.asList(cards)),
-			Arrays.asList(cards[4], cards[5], cards[9], cards[10])));
-		// Card: Green reverse <9>
-		/*
-		 * Expected: Wild, Draw four, Green reverse, Blue reverse
-		 */
-
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.analyzePossibleCards(cards[10], Arrays.asList(cards)),
-			Arrays.asList(cards[0], cards[3], cards[4], cards[5], cards[6], cards[9], cards[10])));
-		// Card: Blue reverse <10>
-		/*
-		 * Expected: Blue 0, Blue 1, Wild, Draw four, Blue draw two, Green reverse, Blue
-		 * reverse
-		 */
 	}
 
 	@Test
@@ -232,9 +131,12 @@ class UnoUtilsTest {
 				/* 7 Wild */ new UnoDrawCard()
 		};
 
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.getNumberCards(3, Arrays.asList(cards)), Arrays.asList(cards[0], cards[1])));
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.getNumberCards(6, Arrays.asList(cards)), Arrays.asList(cards[2], cards[3])));
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.getNumberCards(9, Arrays.asList(cards)), Arrays.asList(cards[4], cards[5])));
+		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.getNumberCards(3, Arrays.asList(cards)),
+			Arrays.asList(cards[0], cards[1])));
+		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.getNumberCards(6, Arrays.asList(cards)),
+			Arrays.asList(cards[2], cards[3])));
+		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.getNumberCards(9, Arrays.asList(cards)),
+			Arrays.asList(cards[4], cards[5])));
 	}
 
 	@Test
@@ -259,6 +161,7 @@ class UnoUtilsTest {
 			Arrays.asList(cards[3], cards[4])));
 		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.filterKind(UnoDrawCard.class, Arrays.asList(cards)),
 			Arrays.asList(cards[5], cards[6])));
-		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.filterKind(UnoWildCard.class, Arrays.asList(cards)), Arrays.asList(cards[7])));
+		assertTrue(TestUtils.listEqualsUnordered(UnoUtils.filterKind(UnoWildCard.class, Arrays.asList(cards)),
+			Arrays.asList(cards[7])));
 	}
 }


### PR DESCRIPTION
**Breaks**:
- [ ] Non-extending code (only extends BasicUnoGame and UnoHand)
- [x] UnoDeck-extending code (creates custom decks with UnoDeck)
- [x] UnoGame-extending code (extends UnoGame directly)
- [ ] UnoCard-extending code (adds custom cards by extending UnoCard)
- [ ] Does not break anything

**Goals:**
- [x] Create a rule modularization system
- [x] Create a card placement type of rule
- [x] Put the old card placement rules into their respective classes
- [x] Add the official "extra hitch" rule for wild draw four
- [x] Integrate the new rule system into BasicUnoGame and the UnoHand-s
- [x] Fully document the additions

**Compliance:**
- [x] Passes all JUnit tests
- [x] Does not cause new SonarLint warnings (except "Info" markers)
- [x] Does not cause new SpotBugs warnings