### PR TITLE
Support for event-based GUI

### DIFF
--- a/src/main/java/com/github/markozajc/juno/game/UnoGame.java
+++ b/src/main/java/com/github/markozajc/juno/game/UnoGame.java
@@ -161,6 +161,7 @@ public abstract class UnoGame {
 	public UnoWinner play() {
 		init();
 		// Initiates game
+		onEvent("The game begins!");
 
 		UnoPlayer winnerPlayer = null;
 

--- a/src/main/java/com/github/markozajc/juno/game/UnoGame.java
+++ b/src/main/java/com/github/markozajc/juno/game/UnoGame.java
@@ -211,6 +211,9 @@ public abstract class UnoGame {
 		turn(player);
 		// Plays player's hand
 
+		updateTopCard();
+		// Update top card to avoid last card not being cached
+
 		for (UnoPlayer otherPlayer : this.players) {
 			if (checkVictory(otherPlayer, this.getDiscard()))
 				return otherPlayer;


### PR DESCRIPTION
If a multiplayer UNO game uses an event-based GUI, the game itself will not receive an onEvent after initialization of discard pile and player hand cards. I've added one and fixed a rather minor bug causing the last card played in a game not being cached in the getTopCard() method.